### PR TITLE
Switch from wikimedia/ip-set to wikimedia/ip-utils

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "ext-curl": "*",
     "ext-json": "*",
     "fakerphp/faker": "^1.20",
-    "wikimedia/ip-set": "^3.1",
+    "wikimedia/ip-utils": "^4.0.1 || ^5.0 || ^6.0",
     "guzzlehttp/guzzle": "^7.5",
     "nesbot/carbon": "^2.0|^3.0",
     "menarasolutions/geographer": "^0.3.13",


### PR DESCRIPTION
See also: [wikimedia/ip-utils](https://packagist.org/packages/wikimedia/ip-utils) and [wikimedia/ip-set](https://packagist.org/packages/wikimedia/ip-set) on Packagist.

* wikimedia/ip-set 1.x renames IPSet to Wikimedia/IPSet and keeps an IPSet alias. This repo already uses Wikimedia/IPSet.
* wikimedia/ip-set 2.0 removes the old IPSet alias.
* wikimedia/ip-utils 4.0 depends on wikimedia/ip-set (2.0, 3.0, or 4.0; which are interchangable and vary only in required PHP version which is auto-selected by Composer).
* wikimedia/ip-utils 5.0 bundles Wikimedia/IPSet and requires PHP 7.4+. The wikimedia/ip-set package is now deprecated.
* wikimedia/ip-utils 6.0 has no breaking changes but raises the requirement to PHP 8.1+.

While this project already requires PHP 8.2, I suggest allowing for IPUtils 4 and 5 (which support older PHP versions) because there are no breaking changes and this eases upgrades and avoids composer-install conflicts for people combining this package with other packages.